### PR TITLE
TensorFlow preprocessing part record and print

### DIFF
--- a/bin/sofa
+++ b/bin/sofa
@@ -87,7 +87,14 @@ if __name__ == "__main__":
         type=str,
         required=False,
         help='filters for network, put your ip into it, eg.192.168.0.100 is 192168000100, and first ip must be your localhost')
-
+    # ===============TF_preprocessing ===============
+    parser.add_argument(
+            '--tf_prepare_filters',
+            metavar='"keyword1:color1,keyword2:color2"',
+            type=str,
+            required=False,
+            help='A string of list of pairs of keyword and color')
+    # ===============================================
     cfg = SOFA_Config()
 
     args = parser.parse_args()
@@ -133,6 +140,11 @@ if __name__ == "__main__":
     cfg.gpu_filters.append(Filter('copyKind_1_', 'Red'))
     cfg.gpu_filters.append(Filter('copyKind_2_', 'Peru'))
     cfg.gpu_filters.append(Filter('copyKind_10_', 'Purple'))
+    # =============== TF_preprocessing filter ====================
+    cfg.tf_prepare_filters.append(Filter('resize','#C1ED99'))
+    cfg.tf_prepare_filters.append(Filter('decode','#99E7ED'))
+    cfg.tf_prepare_filters.append(Filter('batch','#F5A92C'))
+    # ===========================================================
     if args.gpu_filters is not None:
         pairs = args.gpu_filters.split(',')
         for pair in pairs:
@@ -153,7 +165,10 @@ if __name__ == "__main__":
         print_info("CPU filter = %s:%s" % (filter.keyword, filter.color))
     for filter in cfg.gpu_filters:
         print_info("GPU filter = %s:%s" % (filter.keyword, filter.color))
-
+    # ======== TF_preprocessing Filter info print ===============
+    for filter in cfg.tf_prepare_filters:
+        print_info("TF_Prepare filter = %s:%s" % (filter.keyword, filter.color))
+    # ============================================================
     print_info("logdir = %s" % logdir)
 
     if command == 'stat':

--- a/bin/sofa_analyze.py
+++ b/bin/sofa_analyze.py
@@ -345,6 +345,7 @@ def sofa_analyze(logdir, cfg):
     filein_vmstat = logdir + "vmstat_trace.csv"
     
     if os.path.isfile('%s/nvlink_topo.txt' % logdir):
+        
         with open(logdir + 'nvlink_topo.txt') as f:
             lines = f.readlines()
             title = lines[0]
@@ -361,26 +362,18 @@ def sofa_analyze(logdir, cfg):
                         edges.append((i,j-1))
                         #print('%d connects to %d' % (i, j-1))
             #print(edges)
-            G = nx.DiGraph(edges)           
-            #for cycle in nx.simple_cycles(G):
-            #    if len(cycle) == num_gpus:
-            #        print(("One of the recommended %d rings" % len(cycle) ))
-            #        print(cycle)
-            #        os.system("mkdir -p /tmp/sofa_hints/")
-            #        xring_order = ','.join(map(str, cycle))
-            #        with open("/tmp/sofa_hints/xring_order.txt", "w") as f:
-            #            f.write('export CUDA_VISIBLE_DEVICES=' + xring_order)
-                    # pathlib.Path('/tmp/sofa_hints/xring_order.txt').write_text('export CUDA_VISIBLE_DEVICES=' + xring_order)  # UPGRADE: py35
-                    # pathlib.Path('/tmp/sofa_hints/xring_order.txt').write_text(f'export CUDA_VISIBLE_DEVICES=f{xring_order}')  # UPGRADE: py36
-            #        break
-    #try:
-    #    df_mpstat = pd.read_csv(filein_mpstat)
-    #    mpstat_profile(logdir, cfg, df_mpstat)
-    #except IOError:
-    #    print_warning(
-    #        "vmstat_trace.csv is not found")
-    #    quit()
-
+            if num_gpus > 1:
+                G = nx.DiGraph(edges)           
+                for cycle in nx.simple_cycles(G):
+                    if len(cycle) == num_gpus:
+                        print(("One of the recommended %d rings" % len(cycle) ))
+                        print(cycle)
+                        os.system("mkdir -p /tmp/sofa_hints/")
+                        xring_order = ','.join(map(str, cycle))
+                        with open("/tmp/sofa_hints/xring_order.txt", "w") as f:
+                            f.write('export CUDA_VISIBLE_DEVICES=' + xring_order)
+                        break
+    
     try:
         df_cpu = pd.read_csv(filein_cpu)
         cpu_profile(logdir, cfg, df_cpu)

--- a/bin/sofa_analyze.py
+++ b/bin/sofa_analyze.py
@@ -138,20 +138,6 @@ def comm_profile(logdir, cfg, df_gpu):
         accum[src][dst] = float(accum[src][dst] + payload)
         accum_count[src][dst] = int(accum_count[src][dst] + 1)
 
-    print("Traffic Matrix (log10(B)):")
-    row_str = "\tHOST\t"
-    for i in range(1, accum.shape[1]):
-        row_str = row_str + "GPU%d" % i + "\t"
-    print(row_str)
-    for i in range(accum.shape[0]):
-        if i == 0:
-            row_str = "HOST\t"
-        else:
-            row_str = "GPU%d\t" % i
-        
-        for j in range(accum.shape[1]):
-            row_str = row_str + "%d" % (int(np.log10(1 + accum[i][j]))) + "\t"
-        print(row_str)
 
     print("Traffic Matrix (MB):")
     row_str = "\tHOST\t"
@@ -216,6 +202,7 @@ def gpu_profile(logdir, cfg, df_gpu):
     print_title("Summary of Kernels")
     print(("MeasuredTotalKernelTime : %lf (s)" % total_kernel_time))
     print(("MeasuredAllReduceTime : %lf (s)" % all_reduce_time))
+    get_top_k_events(df_gpu, 10)
 
 
 def net_profile(logdir, cfg, df):
@@ -233,7 +220,7 @@ def net_profile(logdir, cfg, df):
 
 
 def cpu_profile(logdir, cfg, df):
-    print_title("CPU Profiling: Task Time (IO included) for each Cores (s)")
+    print_title("CPU Profiling: Task Time (IO included) for each Core (s)")
     grouped_df = df.groupby("deviceId")["duration"]
     total_exec_time = 0
     for key, item in grouped_df:

--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -846,11 +846,14 @@ def sofa_preprocess(logdir, cfg):
             for line in f :
                 #print(line)
                 if line.find('0.000000') != -1:
-                    keyword = line.split(',')[-1]
-                    if keyword.find('memcpy') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
-                    elif keyword.find('memset') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                    gpu_event_list = line.split(',')
+                    for keyword in reversed(gpu_event_list) :
+                        if keyword.find('memcpy') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
+                        elif keyword.find('memset') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                        elif keyword.find('ParallelForAgent') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL'
             engine = create_engine("sqlite:///"+nvvp_filename)
             gpu_traces_df = pd.read_sql_table(gpu_f_event,engine)
             print(gpu_traces_df.iloc[0]['start'])

--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -849,11 +849,14 @@ def sofa_preprocess(logdir, cfg):
             for line in f :
                 #print(line)
                 if line.find('0.000000') != -1:
-                    keyword = line.split(',')[-1]
-                    if keyword.find('memcpy') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
-                    elif keyword.find('memset') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                    gpu_event_list = line.split(',')
+                    for keyword in reversed(gpu_event_list) :
+                        if keyword.find('memcpy') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
+                        elif keyword.find('memset') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                        elif keyword.find('ParallelForAgent') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL'
             engine = create_engine("sqlite:///"+nvvp_filename)
             gpu_traces_df = pd.read_sql_table(gpu_f_event,engine)
             print(gpu_traces_df.iloc[0]['start'])

--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -15,6 +15,8 @@ from sofa_config import *
 from sofa_print import *
 from random import *
 from sqlalchemy import create_engine
+from sofa_tf_prepare import *
+import shutil 
 
 def list_downsample(list_in, plot_ratio):
     new_list = []
@@ -372,6 +374,13 @@ def sofa_preprocess(logdir, cfg):
     t_glb_base = 0
     t_glb_net_base = 0
     t_glb_gpu_base = 0
+
+    # ==================== Move TF_prepare.binary to logdir ====================
+    try:
+        shutil.move("./TF_prepare.binary",logdir)
+    except:
+        print("There is no TF_prepare.binary file or You don't train/inference with real data.")
+    # ==========================================================================
 
     with open('%s/perf.script' % logdir, 'w') as logfile:
         subprocess.call(['perf',
@@ -814,6 +823,18 @@ def sofa_preprocess(logdir, cfg):
     else:
         print_warning("no network traces were recorded.")
 
+    # ============ TF-prepare Trace ================================
+    filtered_TFPrepare_groups = []
+    try:
+        tf_traces = sofa_tf_prepare(_file='TF_prepare.binary',logdir=logdir)
+        for filter in cfg.tf_prepare_filters:
+            group = tf_traces[tf_traces['name'].str.contains(filter.keyword)]
+            filtered_TFPrepare_groups.append({'group': group,
+                                              'color': filter.color,
+                                              'keyword': filter.keyword})
+    except:
+        print ('sofa_tf_prepare error')
+
     # ============ Preprocessing GPU Trace ==========================
     num_cudaproc = 0
     filtered_gpu_groups = []
@@ -1042,7 +1063,26 @@ def sofa_preprocess(logdir, cfg):
         sofatrace.y_field = 'duration'
         sofatrace.data = filtered_gpu_group['group'].copy()
         traces.append(sofatrace)
+    # ===========TF_prepare_traces =======================
+    sofatrace = SOFATrace()
+    sofatrace.name = 'TF_preapre_trace'
+    sofatrace.title = 'OPs'
+    sofatrace.color = 'rgba(0,0,0,0.8)'
+    sofatrace.x_field = 'timestamp'
+    sofatrace.y_field = 'duration'
+    sofatrace.data = tf_traces
+    traces.append(sofatrace)
 
+    for filtered_TFPrepare_group in filtered_TFPrepare_groups:
+        sofatrace = SOFATrace()
+        sofatrace.name = filtered_TFPrepare_group['keyword']
+        sofatrace.title = 'keyword_' + sofatrace.name
+        sofatrace.color = filtered_TFPrepare_group['color']
+        sofatrace.x_field = 'timestamp'
+        sofatrace.y_field = 'duration'
+        sofatrace.data = filtered_TFPrepare_group['group'].copy()
+        traces.append(sofatrace)
+    # ====================================================
     traces_to_json(traces, logdir + 'report.js', cfg)
     print_progress(
         "Export Overhead Dynamics JSON File of CPU, Network and GPU traces -- end")

--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -135,11 +135,13 @@ def gpu_trace_read(
 
     pid = n_cudaproc
 
+    deviceId = -1 
     try:
         deviceId = int(float(values[indices.index('Context')]))
     except BaseException:
         deviceId = -1
 
+    tid = stream_id = -1
     try:
         tid = streamId = int(float(values[indices.index('Stream')]))
     except BaseException:
@@ -150,17 +152,17 @@ def gpu_trace_read(
         copyKind = 1
         pkt_src = 0
         pkt_dst = deviceId
-        kernel_name = "gpu%d_copyKind_%d_%dB" % (deviceId, copyKind, payload)
+        kernel_name = "copyKind_%d_%dB" % (copyKind, payload)
     elif kernel_name.find('DtoH') != -1:
         copyKind = 2
         pkt_src = deviceId
         pkt_dst = 0
-        kernel_name = "gpu%d_copyKind_%d_%dB" % (deviceId, copyKind, payload)
+        kernel_name = "copyKind_%d_%dB" % (copyKind, payload)
     elif kernel_name.find('DtoD') != -1:
         copyKind = 8
         pkt_src = deviceId
         pkt_dst = deviceId
-        kernel_name = "gpu%d_copyKind_%d_%dB" % (deviceId, copyKind, payload)
+        kernel_name = "copyKind_%d_%dB" % (copyKind, payload)
     elif kernel_name.find('PtoP') != -1:
         copyKind = 10
         try:
@@ -173,10 +175,11 @@ def gpu_trace_read(
         except BaseException:
             pkt_dst = 0
 
-        kernel_name = "gpu%d_copyKind_%d_%dB" % (deviceId, copyKind, payload)
+        kernel_name = "copyKind_%d_from_gpu%d_to_gpu%d_%dB" % (copyKind, pkt_src, pkt_dst, payload)
     else:
         copyKind = 0
 
+    kernel_name = 'gpu%d_'%deviceId + kernel_name
     # print("%d:%d [%s] ck:%d, %lf,%lf: %d -> %d: payload:%d, bandwidth:%lf,
     # duration:%lf "%(deviceId, streamId, kernel_name, copyKind,
     # t_begin,t_end, pkt_src, pkt_dst, payload, bandwidth, duration))
@@ -701,7 +704,7 @@ def sofa_preprocess(logdir, cfg):
                         bandwidth = -1
                         pkt_src = pkt_dst = -1
                         pid = tid = -1
-                        nvsmi_info = "GPUID.sm.mem=%d_%lf_%lf" % (
+                        nvsmi_info = "GPUID_sm_mem=%d_%lf_%lf" % (
                             nvsmi_id, nvsmi_sm, nvsmi_mem)
 
                         trace = [

--- a/bin/sofa_tf_prepare.py
+++ b/bin/sofa_tf_prepare.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import os
+import sys
+
+sofa_fieldnames = [
+            'timestamp',  # 0
+            "event",  # 1
+            "duration",  # 2
+            "deviceId",  # 3
+            "copyKind",  # 4
+            "payload",  # 5
+            "bandwidth",  # 6
+            "pkt_src",  # 7
+            "pkt_dst",  # 8
+            "pid",  # 9
+            "tid",  # 10
+            "name",  # 11
+            "category"]  # 12
+
+TF_fieldnames = [
+        'NAME',  # 0
+        "t_start",
+        "timestamp", #t_start_time
+        "t_end",
+        "t_end_time"]  
+
+def sofa_tf_prepare(_file,logdir):
+    print('In sofa_tf_prepare')
+    sub_string = 't_start'
+    with open(logdir + _file) as f:
+        with open(logdir + '/prepare_tmp.csv','w') as df:
+            for line in f:
+                if sub_string in line:
+                    df.write(line)
+    df = pd.read_csv(logdir + '/prepare_tmp.csv')
+    df.columns = TF_fieldnames
+    prepare_traces = pd.DataFrame()
+    prepare_traces['timestamp'] = df['timestamp']
+    prepare_traces['duration'] = df['t_end_time'] - df['timestamp']
+    prepare_traces['name'] = df['NAME']
+    for col in ('payload', 'bandwidth', 'category'):
+        prepare_traces[col] = 0
+    for col in ('event', 'deviceId', 'copyKind', 'pkt_src', 'pkt_dst', 'pid', 'tid'):
+        prepare_traces[col] = -1
+    prepare_traces[sofa_fieldnames].to_csv(
+            logdir + '/cputrace.csv',
+             mode='a',
+             header=False,
+             index=False,
+             float_format='%.6f')
+    print('sofa_tf_prepare done!')
+    return prepare_traces
+

--- a/tools/prerequisite.sh
+++ b/tools/prerequisite.sh
@@ -38,20 +38,20 @@ function install_python_packages()
     echo -e "${C_GREEN}Installing python packages...${C_NONE}"
      
     if [[ $(which yum) ]]  ; then
-        yum install epel-release
-        yum install https://centos7.iuscommunity.org/ius-release.rpm
-        yum install python36u
-        yum install python36u-pip
+        sudo yum install epel-release
+        sudo yum install https://centos7.iuscommunity.org/ius-release.rpm
+        sudo yum install python36u
+        sudo yum install python36u-pip
     elif [[ "${OS}" == "Ubuntu" ]] && ( [[ "${VERSION}" == "14.04"* ]] || [[ "${VERSION}" == "16.04"* ]] ) ; then	
-        apt-get install software-properties-common -y
-        add-apt-repository ppa:deadsnakes/ppa -y
-        apt-get update -y
-        apt-get install python3.6 -y
+        sudo apt-get install software-properties-common -y
+        sudo add-apt-repository ppa:deadsnakes/ppa -y
+        sudo apt-get update -y
+        sudo apt-get install python3.6 -y
 	    curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
 	    python3.6 get-pip.py
         rm get-pip.py
     elif [[ $(which apt) ]] ; then	
-        apt-get install python3.6 -y
+        sudo apt-get install python3.6 -y
     else
 	    file_pytar="Python-3.6.0.tar.xz"
 	    wget https://www.python.org/ftp/python/3.6.0/$file_pytar
@@ -77,25 +77,25 @@ function install_packages()
 
     #inform_sudo "Running sudo for installing packages"
     if [[ $(which apt) ]] ; then
-        apt-get update
-        apt-get update --fix-missing
-	apt-get install curl wget cmake tcpdump sysstat \
-		libboost-dev libpcap-dev libconfig-dev libconfig++-dev linux-tools-common \
-		linux-tools-$(uname -r) linux-cloud-tools-$(uname -r) linux-tools-generic linux-cloud-tools-generic 
+        sudo apt-get update
+        sudo apt-get update --fix-missing
+	    sudo apt-get install curl wget cmake tcpdump sysstat \
+            libboost-dev libpcap-dev libconfig-dev libconfig++-dev linux-tools-common \
+            linux-tools-$(uname -r) linux-cloud-tools-$(uname -r) linux-tools-generic linux-cloud-tools-generic 
         
 	[[ $? != 0 ]] && echo -e "${C_RED_BK}Failed... :(${C_NONE}" && exit 1
     elif [[ $(which yum) ]]  ; then
-        yum install epel-release 
-        yum install \
+        sudo yum install epel-release 
+        sudo yum install \
             perf tcpdump\
             centos-release-scl devtoolset-4-gcc* sysstat
         [[ $? != 0 ]] && echo -e "${C_RED_BK}Failed... :(${C_NONE}" && exit 1
     elif [[ $(which dnf) ]]  ; then
-        dnf -y install \
+        sudo dnf -y install \
             perf cmake tcpdump boost-devel libconfig-devel libpcap-devel cmake sysstat
         [[ $? != 0 ]] && echo -e "${C_RED_BK}Failed... :(${C_NONE}" && exit 1
     elif [[ $(which pacman) ]]  ; then
-        pacman -S \
+        sudo pacman -S \
             linux-tools cmake boost cmake tcpdump sysstat
     else
         echo -e "${C_RED_BK}This script does not support your OS distribution, '$OS'. Please install the required packages by yourself. :(${C_NONE}"


### PR DESCRIPTION
As title, I add sofa_tf_prepare.py to read the TF_prepare.binary, which contains most of the TensorFlow real data prepare events' name, start time, and end time. 
Before using my PR, please use this version of [TensorFlow](https://github.com/softDi/tensorflow/tree/TF_prepare) (in TF_prepare branch) ,which will get TF_prepare.binary.
Then, sofa report will mv the TF_prepare.binary in logdir and read it and print TF_prepare result on the website.




