### PR TITLE
fix multi-gpus bug

### DIFF
--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -828,11 +828,14 @@ def sofa_preprocess(logdir, cfg):
             for line in f :
                 #print(line)
                 if line.find('0.000000') != -1:
-                    keyword = line.split(',')[-1]
-                    if keyword.find('memcpy') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
-                    elif keyword.find('memset') != -1:
-                        gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                    gpu_event_list = line.split(',')
+                    for keyword in reversed(gpu_event_list) :
+                        if keyword.find('memcpy') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMCPY'
+                        elif keyword.find('memset') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_MEMSET'
+                        elif keyword.find('ParallelForAgent') != -1:
+                            gpu_f_event = 'CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL'
             engine = create_engine("sqlite:///"+nvvp_filename)
             gpu_traces_df = pd.read_sql_table(gpu_f_event,engine)
             print(gpu_traces_df.iloc[0]['start'])


### PR DESCRIPTION
I fix the multi-GPUs bug.
The gputrace.tmp contents, which we get from one machine with 2 GPU cards, is different from the contents we get from one machine with 1 GPU card.
Since there is another element in the last column when we use one machine with 2 GPU cards, the previous method is unable to get the first event name of GPU.
Furthermore, there is another GPU event name when we run the benchmark in distributed mode.
I add a new event to make sure the GPU time is correct.