### PR TITLE
Add --enable_py_stacks options for recording

### DIFF
--- a/bin/sofa
+++ b/bin/sofa
@@ -91,6 +91,9 @@ if __name__ == "__main__":
     parser.set_defaults(aisi_via_strace=False)
     parser.add_argument('--display_swarms', dest='display_swarms', action='store_true')
     parser.set_defaults(display_swarms=False)
+    parser.add_argument('--enable_py_stacks', dest='enable_py_stacks', action='store_true', required=False, 
+                            help='Record the callstack of python program via py-spy')
+    parser.set_defaults(enable_py_stacks=False)
     parser.add_argument('--base_logdir', dest='base_logdir', default='')
     parser.add_argument('--match_logdir', dest='match_logdir', default='')
     parser.add_argument('--hsg_multifeatures', dest='hsg_multifeatures', action='store_true')
@@ -166,6 +169,9 @@ if __name__ == "__main__":
 
     if args.aisi_via_strace is not None:
         cfg.aisi_via_strace = args.aisi_via_strace
+
+    if args.enable_py_stacks is not None:
+        cfg.enable_py_stacks = args.enable_py_stacks
 
     if args.hsg_multifeatures is not None:
         cfg.hsg_multifeatures = args.hsg_multifeatures

--- a/bin/sofa_config.py
+++ b/bin/sofa_config.py
@@ -45,3 +45,4 @@ class SOFA_Config:
     timeout = 30
     columns = ['timestamp', 'duration']
     enable_strace = False
+    enable_py_stacks = False

--- a/bin/sofa_record.py
+++ b/bin/sofa_record.py
@@ -135,6 +135,7 @@ def sofa_record(command, cfg):
     p_pcm_numa = None 
     logdir = cfg.logdir
     p_strace = None
+    p_pystack = None
     print_info(cfg,'SOFA_COMMAND: %s' % command)
     sample_freq = 99
     command_prefix = ''
@@ -285,6 +286,15 @@ def sofa_record(command, cfg):
         print_hint('PID of the target program: %d' % target_pid)
         print_hint('Command: %s' % command)
 
+
+        if cfg.enable_py_stacks:
+            if command.find('python') == -1:
+                print_warning("Not a python program to recorded, skip recording callstacks")
+            elif cfg.enable_strace:
+                print_warning("Only one of --enable_py_stacks or --enable_strace option holds, ignore --enable_py_stack options")
+            else:
+                command_prefix = ' '.join(['py-spy','-n', '-s', '{}/pystacks.txt'.format(logdir), '-d', str(sys.maxsize), '--']) + ' '
+        
 
         if cfg.enable_strace:
             command_prefix = ' '.join(['strace', '-q', '-T', '-t', '-tt', '-f', '-o', '%s/strace.txt'%logdir]) + ' '

--- a/tools/install_pystacks.sh
+++ b/tools/install_pystacks.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo -e "Installing Rust with using rustup"
+curl https://sh.rustup.rs -sSf | sh
+source $HOME/.cargo/env
+
+
+echo -e "Installing py-spy with specific version fo sofa"
+git clone https://github.com/notreal1995/py-spy.git
+cd py-spy
+python3.6 setup.py install
+cd ..
+
+


### PR DESCRIPTION
`tools/install_pystacks.sh` is a simple example for installing Rust and py-spy. It's should be a more proper way to install

Since [py-spy](https://github.com/benfred/py-spy) dumps by
> Looking at the global PyInterpreterState variable to get all the Python threads running in the interpreter, and then iterating over each PyFrameObject in each thread to get the call stack

which is different from [pyflame](https://pyflame.readthedocs.io/en/latest/faq.html)

Hence the result is messy enough and I will find a suitable method to handle it



