### PR TITLE
Diskstat rewrite

### DIFF
--- a/bin/sofa_analyze.py
+++ b/bin/sofa_analyze.py
@@ -577,15 +577,15 @@ def blktrace_latency_profile(logdir, cfg, df, features):
 def diskstat_profile(logdir, cfg, df, features):
     print_title("DISKSTAT Profiling:")
     print('Disk Throughput Quartile :')
-    diskstat_q1 = df['duration'].quantile(0.25)
-    diskstat_q2 = df['duration'].quantile(0.5)
-    diskstat_q3 = df['duration'].quantile(0.75)
-    diskstat_mean = df['duration'].mean()
+    diskstat_q1 = df['bandwidth'].quantile(0.25)
+    diskstat_q2 = df['bandwidth'].quantile(0.5)
+    diskstat_q3 = df['bandwidth'].quantile(0.75)
+    diskstat_mean = df['bandwidth'].mean()
 
-    print('Q1 disk throughput : %s' % convertbytes(diskstat_q1))
-    print('Q2 disk throughput : %s' % convertbytes(diskstat_q2))
-    print('Q3 disk throughput : %s' % convertbytes(diskstat_q3))
-    print('Avg disk throughput : %s' % convertbytes(diskstat_mean))
+    print('Q1 disk throughput : %.2f MB/s' % diskstat_q1)
+    print('Q2 disk throughput : %.2f MB/s' % diskstat_q2)
+    print('Q3 disk throughput : %.2f MB/s' % diskstat_q3)
+    print('Avg disk throughput : %.2f MB/s' % diskstat_mean)
     
     df_feature = pd.DataFrame({ 'name':['diskstat_q1','diskstat_q2','diskstat_q3'], 
                         'value': [diskstat_q1, diskstat_q2,  diskstat_q3] }, 

--- a/bin/sofa_preprocess.py
+++ b/bin/sofa_preprocess.py
@@ -547,21 +547,26 @@ def sofa_preprocess(cfg):
             d_read *= secsize
             d_write = int(m[3]) - int(m_last[3])
             d_write *= secsize
-            d_disk_total = d_read + d_write
-            d_disk_total *= secsize
+            d_disk_total = d_read + d_write #total bytes
+            
             if not d_disk_total:
                 continue
-            t_begin = float(m[0])
+            t_begin = float(m_last[0])
 
             if not cfg.absolute_timestamp:
                 t_begin = t_begin - cfg.time_base     
             
+            d_duration = float(m[0]) - float(m_last[0])
+
+            # MB/s
+            d_throughput = round((d_disk_total/d_duration)/float(1024 ** 2),2)
+
             event = -1
-            rw = d_disk_total
-            deviceId = -1
+            duration = d_duration
+            deviceId = m[1]
             copyKind = -1
-            payload = -1
-            bandwidth = -1
+            payload = d_disk_total
+            bandwidth = d_throughput
             pkt_src = -1
             pkt_dst = -1
             pid = -1
@@ -570,7 +575,7 @@ def sofa_preprocess(cfg):
             trace = [
                 t_begin,
                 event,
-                rw,
+                duration,
                 deviceId,
                 copyKind,
                 payload,
@@ -1954,10 +1959,10 @@ def sofa_preprocess(cfg):
     if cfg.enable_diskstat:
         sofatrace = SOFATrace()
         sofatrace.name = 'diskstat'
-        sofatrace.title = 'DISK_USAGE'
+        sofatrace.title = 'DISK_USAGE (MB/s)'
         sofatrace.color = 'GreenYellow'
         sofatrace.x_field = 'timestamp'
-        sofatrace.y_field = 'duration'
+        sofatrace.y_field = 'bandwidth'
         sofatrace.data = diskstat_traces
         traces.append(sofatrace)
 

--- a/bin/sofa_record.py
+++ b/bin/sofa_record.py
@@ -98,7 +98,8 @@ def get_diskstat(logdir):
         for line in lines:
             m = line[:-1]
             m = line.split()
-            stat_list.append([unix_time]+[m[2]]+[m[5]]+[m[9]])
+            if re.search(r'sd\D$',m[2]):
+                stat_list.append([unix_time]+[m[2]]+[m[5]]+[m[9]])
         df_stat = pd.DataFrame(stat_list)
         df_stat.to_csv("%s/diskstat.txt" % logdir, mode='a', header=False, index=False, index_label=False)
 


### PR DESCRIPTION
The original **Diskstat preprocess** treated **Total bytes transfer (read and write events during _sofa record_) * sector size** as the throughput of the disk. However, it seemed wrong. 

In this PR, I rewrote the **Diskstat** part and made it concentrate on **sd[x]**.
 