### PR TITLE
Add plugins and bin to PYTHONPATH in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,8 @@ function install_sofa()
     cat > ${PREFIX}/tools/activate.sh <<EOF
 export PATH=${PREFIX}/bin:\$PATH
 export PATH=\$PATH:/usr/local/cuda/bin
+export PYTHONPATH=\$PYTHONPATH:${PREFIX}/plugins
+export PYTHONPATH=\$PYTHONPATH:${PREFIX}/bin
 EOF
 ##################
 


### PR DESCRIPTION
Add the directories plugins/ and bin/ to the environment variable `PYTHONPATH` when user run activate.sh.

It is useful when tools developers want to modify SOFA codes in bin/ and import his tools, which are placed under plugins/ directory. Occasionally, these custom tools might need access to SOFA functionality such as SOFATrace, SOFA_Config, sofa_print, etc.

This patch allows python to automatically search for packages under plugins/ and files under bin/.